### PR TITLE
[TEST] Add Linux 5.9-rc1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 # also bump pve-kernel-meta if either of MAJ.MIN, PATCHLEVEL or KREL change
 KERNEL_MAJ=5
-KERNEL_MIN=8
-KERNEL_PATCHLEVEL=9
+KERNEL_MIN=9
+KERNEL_PATCHLEVEL=0
 # increment KREL if the ABI changes (abicheck target in debian/rules)
 # rebuild packages with new KREL and run 'make abiupdate'
 KREL=1
 
-PKGREL=1
+PKGREL=0rc1
 PKGRELLOCAL=1
 PKGRELFULL=${PKGREL}
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pve-edge-kernel (5.9.0-0rc1) edge; urgency=medium
+
+  * Update to Linux 5.9.0 based on Ubuntu 5.8.0-8.9.
+
+ -- Fabian Mastenbroek <mail.fabianm@gmail.com>  Fri, 18 Sep 2020 10:04:49 +0000
+
 pve-edge-kernel (5.8.9-1) edge; urgency=medium
 
   * update to Linux 5.8.9 based on Ubuntu-5.8.0-19.20


### PR DESCRIPTION
This change updates the kernel to Linux 5.9.0 based on Ubuntu .

**Changelog:**
```
Source: pve-edge-kernel
Version: 5.9.0-0rc1
Distribution: edge
Urgency: medium
Maintainer: Fabian Mastenbroek <mail.fabianm@gmail.com>
Timestamp: 1600423489
Date: Fri, 18 Sep 2020 10:04:49 +0000
Changes:
 pve-edge-kernel (5.9.0-0rc1) edge; urgency=medium
 .
   * Update to Linux 5.9.0 based on Ubuntu 5.8.0-8.9.
```