### PR TITLE
Add Linux 5.11-rc6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ KERNEL_MIN=11
 KERNEL_PATCHLEVEL=0
 # increment KREL if the ABI changes (abicheck target in debian/rules)
 # rebuild packages with new KREL and run 'make abiupdate'
-KREL=0rc5
+KREL=0rc6
 
-PKGREL=0rc5
+PKGREL=0rc6
 PKGRELLOCAL=1
 PKGRELFULL=${PKGREL}
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pve-edge-kernel (5.11.0-0rc6) edge; urgency=medium
+
+  * Update to Linux 5.11-rc6 based on unstable/master.
+
+ -- Fabian Mastenbroek <mail.fabianm@gmail.com>  Mon, 1 Feb 2021 13:57:00 +0000
+
 pve-edge-kernel (5.11.0-0rc5) edge; urgency=medium
 
   * Update to Linux 5.11-rc5 based on unstable/master-5.11.


### PR DESCRIPTION
This change updates the kernel to Linux 5.11-rc6 based on unstable/master.