### PR TITLE
Add Linux 5.11.0-2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ KERNEL_MIN=11
 KERNEL_PATCHLEVEL=0
 # increment KREL if the ABI changes (abicheck target in debian/rules)
 # rebuild packages with new KREL and run 'make abiupdate'
-KREL=1
+KREL=2
 
-PKGREL=1
+PKGREL=2
 PKGRELLOCAL=1
 PKGRELFULL=${PKGREL}
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pve-edge-kernel (5.11.0-2) edge; urgency=medium
+
+  * Properly add module.lds to headers package.
+
+ -- Fabian Mastenbroek <mail.fabianm@gmail.com>  Thu, 18 Feb 2021 10:49:30 +0000
+
 pve-edge-kernel (5.11.0-1) edge; urgency=medium
 
   * Update to Linux 5.11.0 based on Ubuntu .

--- a/debian/rules
+++ b/debian/rules
@@ -194,6 +194,10 @@ binary: install
 	        xargs -n1 -i: find : -type f \
 	    ) | \
 	    cpio -pd --preserve-modification-time ${BUILD_DIR}/debian/${PVE_HEADER_PKG}/usr/src/linux-headers-${KVNAME}
+	# Workaround for #48
+	mv ${BUILD_DIR}/debian/${PVE_HEADER_PKG}/usr/src/linux-headers-${KVNAME}/scripts/module.lds.S \
+	    ${BUILD_DIR}/debian/${PVE_HEADER_PKG}/usr/src/linux-headers-${KVNAME}/scripts/module.lds
+	sed -i '$$ d' ${BUILD_DIR}/debian/${PVE_HEADER_PKG}/usr/src/linux-headers-${KVNAME}/scripts/module.lds
 	touch $@
 
 .headers_compile_mark: .headers_prepare_mark


### PR DESCRIPTION
This pull request adds a new release for Linux 5.11.0 that includes a fix for the missing `module.lds` file in the headers package.