### PR TITLE
Release Kernels via Cloudsmith

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         path: "*.deb"
    publish:
     name: Publish
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     needs: build
     steps:
@@ -81,3 +81,12 @@ jobs:
         body: ${{ steps.format_release.outputs.changelog }}
         token: ${{ secrets.PAT }}
         artifacts: "artifacts/debs-generic/pve-headers-*.deb,artifacts/debs-generic/linux-tools-*.deb,artifacts/debs-*/pve-kernel-*.deb"
+    - name: Release to CloudSmith
+      run: |
+        pip install --upgrade cloudsmith-cli
+        find artifacts/debs-generic \
+          -name '*.deb' \
+          -not -name "*dbgsym*" \
+          -exec cloudsmith push deb pve-edge/kernel/any-distro/any-version {} --republish \;
+      env:
+        CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,30 @@ Custom Linux kernels for Proxmox VE 6.
 2. [Navi Reset](https://github.com/fabianishere/pve-edge-kernel/issues/5)
 
 ## Installation
-Select from the [Releases](https://github.com/fabianishere/pve-edge-kernel/releases)
+[![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=flat-square)](https://cloudsmith.com)
+
+First, set up our Debian repository on your Proxmox installation: 
+1. Add the repository's GPG key:
+```bash
+curl -1sLf 'https://dl.cloudsmith.io/public/pve-edge/kernel/gpg.8EC01CCF309B98E7.key' | apt-key add -
+```
+2. Set up the `pve-edge-kernel` repository:
+```bash
+echo "deb https://dl.cloudsmith.io/public/pve-edge/kernel/deb/debian bullseye main" > /etc/apt/sources.list.d/pve-edge-kernel.list
+```
+3. Install a kernel package:
+```bash
+apt update
+apt install pve-kernel-5.12-edge
+```
+
+Package repository hosting is graciously provided by  [Cloudsmith](https://cloudsmith.com).
+Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that
+enables your organization to create, store and share packages in any format, to any place, with total
+confidence.
+
+### Manual
+Alternatively, you may manually install the kernels. Select from the [Releases](https://github.com/fabianishere/pve-edge-kernel/releases)
 page the kernel version you want to install and download the appropriate Debian package. 
 Then, you can install the package as follows:
 

--- a/debian/templates/control.in
+++ b/debian/templates/control.in
@@ -40,6 +40,26 @@ Description: Linux kernel version specific tools for version @KVMAJMIN@
  This package provides the architecture dependent parts for kernel
  version locked tools (such as perf and x86_energy_perf_policy)
 
+Package: pve-headers-@KVMAJMIN@-edge
+Architecture: all
+Section: admin
+Priority: optional
+Depends: pve-headers-@KVNAME@,
+Description: Latest Proxmox Edge Kernel Headers
+ This is a metapackage which will install the kernel headers
+ for the latest available Proxmox Edge kernel from the @KVMAJMIN@
+ series.
+
+Package: pve-kernel-@KVMAJMIN@-edge
+Architecture: all
+Section: admin
+Priority: optional
+Depends: pve-firmware,
+         pve-kernel-@KVNAME@,
+Description: Latest Proxmox Edge Kernel Image
+ This is a metapackage which will install the latest available
+ Proxmox Edge kernel from the @KVMAJMIN@ series.
+
 Package: pve-headers-@KVNAME@
 Section: devel
 Priority: optional
@@ -47,8 +67,8 @@ Architecture: any
 Provides: linux-headers,
           linux-headers-2.6,
 Depends:
-Description: The Proxmox PVE Kernel Headers
- This package contains the linux kernel headers
+Description: The Proxmox Edge Kernel Headers
+ This package contains the Proxmox Edge Linux kernel headers
 
 Package: pve-kernel-@KVNAME@
 Section: admin
@@ -61,7 +81,7 @@ Depends: busybox,
          initramfs-tools,
 Recommends: grub-pc | grub-efi-amd64 | grub-efi-ia32 | grub-efi-arm64,
 Description: The Proxmox PVE Kernel Image
- This package contains the linux kernel and initial ramdisk used for booting
+ This package contains the Linux kernel and initial ramdisk used for booting
 
 Package: pve-kernel-libc-dev
 Section: devel


### PR DESCRIPTION
This pull request updates the repository to release new kernel releases to a Cloudsmith Debian repository.
With this, users can just add a repository and install the packages from there. This is graciously made possible by the Open Source tier from Cloudsmith. 

Resolves #12 