### PR TITLE
Update to ZFS 2.1.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 pve-kernel (5.16.0-1) edge; urgency=medium
 
   * Disable UBNSAN (see issue #164 and #200).
+  * Update to ZFS 2.1.2
 
  -- Fabian Mastenbroek <mail.fabianm@gmail.com>  Wed, 10 Nov 2021 10:15:00 +0000
 


### PR DESCRIPTION
This change updates the ZFS version to 2.1.2 which supports kernels 3.10 to 5.15.