### PR TITLE
Update to ZFS 2.1.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pve-kernel (5.15.11-2) edge; urgency=medium
+
+  * Update to ZFS 2.1.2.
+
+ -- Fabian Mastenbroek <mail.fabianm@gmail.com>  Wed, 29 Dec 2021 12:00:00 +0000
+
 pve-kernel (5.15.11-1) edge; urgency=medium
 
   * Update to Linux 5.15.11.


### PR DESCRIPTION
This change updates the ZFS version to 2.1.2 which supports kernels 3.10 to 5.15.