### PR TITLE
[v5.16.x] Update to ZFS 2.1.4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pve-kernel (5.16.17-2) edge; urgency=high
+
+  * Update to ZFS 2.1.4.
+
+ -- Fabian Mastenbroek <mail.fabianm@gmail.com>  Sat, 26 Mar 2022 20:00:00 +0000
+
 pve-kernel (5.16.17-1) edge; urgency=medium
 
   * Update to Linux 5.16.17.

--- a/debian/patches/series.zfs
+++ b/debian/patches/series.zfs
@@ -9,4 +9,3 @@ zfs/0008-Add-systemd-unit-for-importing-specific-pools.patch
 zfs/0009-Patch-move-manpage-arcstat-1-to-arcstat-8.patch
 zfs/0010-arcstat-Fix-integer-division-with-python3.patch
 zfs/0011-arc-stat-summary-guard-access-to-l2arc-MFU-MRU-stats.patch
-zfs/0012-Fix-zvol_open-lock-inversion.patch

--- a/debian/patches/zfs/0001-Check-for-META-and-DCH-consistency-in-autoconf.patch
+++ b/debian/patches/zfs/0001-Check-for-META-and-DCH-consistency-in-autoconf.patch
@@ -10,7 +10,7 @@ Signed-off-by: Thomas Lamprecht <t.lamprecht@proxmox.com>
  1 file changed, 29 insertions(+), 5 deletions(-)
 
 diff --git a/config/zfs-meta.m4 b/config/zfs-meta.m4
-index b3c1befaa..660d8ccb9 100644
+index 20064a0fb..4d5f545ad 100644
 --- a/config/zfs-meta.m4
 +++ b/config/zfs-meta.m4
 @@ -1,9 +1,10 @@
@@ -67,4 +67,4 @@ index b3c1befaa..660d8ccb9 100644
 +		elif test ! -f ".nogitrelease" && git rev-parse --git-dir > /dev/null 2>&1; then
  			_match="${ZFS_META_NAME}-${ZFS_META_VERSION}"
  			_alias=$(git describe --match=${_match} 2>/dev/null)
- 			_release=$(echo ${_alias}|cut -f3- -d'-'|sed 's/-/_/g')
+ 			_release=$(echo ${_alias}|sed "s/${ZFS_META_NAME}//"|cut -f3- -d'-'|tr - _)

--- a/debian/patches/zfs/0005-Enable-zed-emails.patch
+++ b/debian/patches/zfs/0005-Enable-zed-emails.patch
@@ -9,23 +9,14 @@ behavior of mdadm.
 
 Signed-off-by: Thomas Lamprecht <t.lamprecht@proxmox.com>
 ---
- cmd/zed/zed.d/zed.rc | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ cmd/zed/zed.d/zed.rc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/cmd/zed/zed.d/zed.rc b/cmd/zed/zed.d/zed.rc
-index df560f921..4ce7af744 100644
+index 9ac77f929..672617f54 100644
 --- a/cmd/zed/zed.d/zed.rc
 +++ b/cmd/zed/zed.d/zed.rc
-@@ -15,7 +15,7 @@
- # Email will only be sent if ZED_EMAIL_ADDR is defined.
- # Disabled by default; uncomment to enable.
- #
--#ZED_EMAIL_ADDR="root"
-+ZED_EMAIL_ADDR="root"
- 
- ##
- # Name or path of executable responsible for sending notifications via email;
-@@ -41,7 +41,7 @@
+@@ -41,7 +41,7 @@ ZED_EMAIL_ADDR="root"
  ##
  # Minimum number of seconds between notifications for a similar event.
  #

--- a/debian/patches/zfs/0008-Add-systemd-unit-for-importing-specific-pools.patch
+++ b/debian/patches/zfs/0008-Add-systemd-unit-for-importing-specific-pools.patch
@@ -31,7 +31,7 @@ index e4056a92c..030611419 100644
  enable zfs-mount.service
  enable zfs-share.service
 diff --git a/etc/systemd/system/Makefile.am b/etc/systemd/system/Makefile.am
-index c374a52ac..25d1b99d7 100644
+index 5e65e1db4..8e6baeb68 100644
 --- a/etc/systemd/system/Makefile.am
 +++ b/etc/systemd/system/Makefile.am
 @@ -7,6 +7,7 @@ systemdunit_DATA = \


### PR DESCRIPTION
This change updates the ZFS project to version 2.1.4, following some
critical issues with 2.1.3.
See https://github.com/fabianishere/pve-edge-kernel/issues/261 for more
information regarding this problem.