### PR TITLE
Fix set-output deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,13 +67,12 @@ jobs:
     - name: Format Release Name
       id: format_release
       run: |
-        release=$(scripts/version.sh)
-        echo "::set-output name=release::$release"
+        echo "release=$(scripts/version.sh)" >> $GITHUB_OUTPUT
         changelog=$(dpkg-parsechangelog -c 1 -l debian/changelog)
         changelog="${changelog//'%'/'%25'}"
         changelog="${changelog//$'\n'/'%0A'}"
         changelog="${changelog//$'\r'/'%0D'}"
-        echo "::set-output name=changelog::$changelog"
+        echo "changelog=$changelog" >> $GITHUB_OUTPUT
     - name: Create Release
       uses: ncipollo/release-action@v1
       with:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -33,14 +33,14 @@ jobs:
         VERSION_OPT=${VERSION:+-v ${VERSION}}
         RELEASE_OPT=${RELEASE:+-r ${RELEASE}}
         ./scripts/update.sh -t ${{ github.event.inputs.tag }} $VERSION_OPT $RELEASE_OPT
-        echo "::set-output name=version::$(scripts/version.sh -L)"
-        echo "::set-output name=full::$(scripts/version.sh)"
+        echo "version=$(scripts/version.sh -L)" >> $GITHUB_OUTPUT
+        echo "full=$(scripts/version.sh)" >> $GITHUB_OUTPUT
         changelog=$(dpkg-parsechangelog -c 1 -l debian/changelog)
         changelog="${changelog//'%'/'%25'}"
         changelog="${changelog//$'\n'/'%0A'}"
         changelog="${changelog//$'\r'/'%0D'}"
-        echo "::set-output name=changelog::$changelog"
-        echo "::set-output name=branch::${GITHUB_REF##*/}"
+        echo "changelog=$changelog" >> $GITHUB_OUTPUT
+        echo "branch=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:

--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -35,7 +35,7 @@ jobs:
             exit 0
         fi
         echo "No staging update found: triggering update"
-        echo "::set-output name=version::$NEW"
+        echo "version=$NEW" >> $GITHUB_OUTPUT
     - name: Trigger Update
       if: ${{ steps.check.outputs.version }}
       uses: benc-uk/workflow-dispatch@v1


### PR DESCRIPTION
GitHub has deprecated the use of `set-output` in Actions: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands

This PR fixes that by using the new `echo "{name}={value}" >> $GITHUB_OUTPUT` syntax instead of `set-output`.